### PR TITLE
Improve haiku generator error handling

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,6 +19,9 @@ export default function Home() {
       });
 
       const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data.error || 'API Error');
+      }
       setHaiku(data.haiku);
     } catch (error) {
       console.error('API取得エラー', error)


### PR DESCRIPTION
## Summary
- handle failed API responses in the React page

## Testing
- `npm run lint` *(fails: next not found)*